### PR TITLE
Fixed logo compression issue on mobile website

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1934,7 +1934,7 @@ input::-moz-focus-inner {
 
   .header-logo {
     left: 40px;
-    top: 3rem;
+    top: -3rem;
     -webkit-transform: translateY(0);
     -ms-transform: translateY(0);
     transform: translateY(0);
@@ -1942,7 +1942,7 @@ input::-moz-focus-inner {
 
   .header-logo img {
     width: 120px;
-    height: 34px;
+    height: auto;
   }
 
   .s-header.sticky .header-logo {
@@ -1954,7 +1954,7 @@ input::-moz-focus-inner {
   }
 
   .header-menu-toggle {
-    top: 3rem;
+    top: 1rem;
     right: 40px;
   }
 

--- a/css/main.css
+++ b/css/main.css
@@ -1696,6 +1696,12 @@ input::-moz-focus-inner {
   z-index: 500;
 }
 
+.s-header__team{
+    position: sticky !important;
+    top: 0 !important;
+    margin-top: 4.2rem;
+}
+
 .s-header > .row {
   position: relative;
   height: 72px;
@@ -1925,6 +1931,7 @@ input::-moz-focus-inner {
 @media only screen and (max-width:800px) {
   .s-header {
     top: 0;
+    margin-top: 0;
   }
 
   .s-header > .row {

--- a/team.html
+++ b/team.html
@@ -75,7 +75,7 @@
 
     <!-- header
     ================================================== -->
-    <header class="s-header">
+    <header class="s-header s-header__team">
 
         <div class="row" style="background-color: black;">
 


### PR DESCRIPTION
Fixes issue number #14 and #17.

Changed navigation to sticky for Team section for correct placement. Added margins to preserve the desired view.
Set height to auto to prevent image logo compression in mobile screen. Adjusted navigation icon position accordingly.


**Before Fix:**
![Screenshot from 2019-07-16 01-13-18](https://user-images.githubusercontent.com/44468673/61284397-7e974f80-a7dc-11e9-8146-1f2b6255cc44.png)
![WhatsApp Image 2019-07-15 at 10 27 30 PM](https://user-images.githubusercontent.com/44468673/61284403-83f49a00-a7dc-11e9-980a-712a23e3d474.jpeg)


**After Fix:**
![Screenshot from 2019-07-16 15-08-16](https://user-images.githubusercontent.com/44468673/61284283-42fc8580-a7dc-11e9-9e6e-85dcbfe6f529.png)
![Screenshot from 2019-07-16 15-06-20](https://user-images.githubusercontent.com/44468673/61284284-42fc8580-a7dc-11e9-90e9-ba9de2366d83.png)
![Screenshot from 2019-07-16 15-06-13](https://user-images.githubusercontent.com/44468673/61284285-42fc8580-a7dc-11e9-826f-e3227436e75d.png)




